### PR TITLE
Use hi def

### DIFF
--- a/plugin/semshi.vim
+++ b/plugin/semshi.vim
@@ -1,17 +1,17 @@
-hi semshiLocal           ctermfg=209 guifg=#ff875f
-hi semshiGlobal          ctermfg=214 guifg=#ffaf00
-hi semshiImported        ctermfg=214 guifg=#ffaf00 cterm=bold gui=bold
-hi semshiParameter       ctermfg=75  guifg=#5fafff
-hi semshiParameterUnused ctermfg=117 guifg=#87d7ff cterm=underline gui=underline
-hi semshiFree            ctermfg=218 guifg=#ffafd7
-hi semshiBuiltin         ctermfg=207 guifg=#ff5fff
-hi semshiAttribute       ctermfg=49  guifg=#00ffaf
-hi semshiSelf            ctermfg=249 guifg=#b2b2b2
-hi semshiUnresolved      ctermfg=226 guifg=#ffff00 cterm=underline gui=underline
-hi semshiSelected        ctermfg=231 guifg=#ffffff ctermbg=161 guibg=#d7005f
+hi def semshiLocal           ctermfg=209 guifg=#ff875f
+hi def semshiGlobal          ctermfg=214 guifg=#ffaf00
+hi def semshiImported        ctermfg=214 guifg=#ffaf00 cterm=bold gui=bold
+hi def semshiParameter       ctermfg=75  guifg=#5fafff
+hi def semshiParameterUnused ctermfg=117 guifg=#87d7ff cterm=underline gui=underline
+hi def semshiFree            ctermfg=218 guifg=#ffafd7
+hi def semshiBuiltin         ctermfg=207 guifg=#ff5fff
+hi def semshiAttribute       ctermfg=49  guifg=#00ffaf
+hi def semshiSelf            ctermfg=249 guifg=#b2b2b2
+hi def semshiUnresolved      ctermfg=226 guifg=#ffff00 cterm=underline gui=underline
+hi def semshiSelected        ctermfg=231 guifg=#ffffff ctermbg=161 guibg=#d7005f
 
-hi semshiErrorSign       ctermfg=231 guifg=#ffffff ctermbg=160 guibg=#d70000
-hi semshiErrorChar       ctermfg=231 guifg=#ffffff ctermbg=160 guibg=#d70000
+hi def semshiErrorSign       ctermfg=231 guifg=#ffffff ctermbg=160 guibg=#d70000
+hi def semshiErrorChar       ctermfg=231 guifg=#ffffff ctermbg=160 guibg=#d70000
 sign define semshiError text=E> texthl=semshiErrorSign
 
 


### PR DESCRIPTION
Using `hi def` instead of just `hi` makes it a lot easier to change the highlighting without autocommands, for example in color schemes.