### PR TITLE
Highlight if filetype is 'python'

### DIFF
--- a/rplugin/python3/semshi/plugin.py
+++ b/rplugin/python3/semshi/plugin.py
@@ -87,6 +87,13 @@ class Plugin:
             self._update_viewport()
             self._cur_handler.update()
 
+    @neovim.autocmd('FileType', pattern='python', sync=True)
+    @if_active
+    def event_file_type(self):
+        if self._cur_handler.enabled:
+            self._update_viewport()
+            self._mark_selected()
+
     @neovim.autocmd('VimResized', pattern=_pattern, sync=False)
     @if_active
     def event_vim_resized(self):


### PR DESCRIPTION
This PR adds support for semantic highlighting of python files without a `.py` extension. It is based on [this](https://github.com/numirias/semshi/issues/35#issuecomment-481236950) comment on #35.

This PR only adds the possibility for highlighting, it does not enable it. I could not find a way to achieve this. As I understand things Semshi is enabled in the [BufferHandler](https://github.com/numirias/semshi/blob/master/rplugin/python3/semshi/handler.py#L45-L46) based on the file extension. [pynvim](https://pynvim.readthedocs.io/en/latest/api/buffer.html) does not seem to supply the file type.

Anyway,  you can call `:Semshi enable` in any python file now and have beautiful semantic highlighting.

Resolves #35