### PR TITLE
 Implement trigger on filetypes + refactorings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ You can set these options in your vimrc (`~/.config/nvim/init.vim`):
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `g:semshi#active` | `v:true` | Activate event handlers. |
-| `g:semshi#excluded_buffers` | `[]` | List of buffer names (glob matching) in which to disable highlighting. (Use `['*']` to disable initial highlighting in all files. You can still re-enable it on demand with  `:Semshi enable`.) |
+| `g:semshi#filetypes` | `['python']` | List of file types on which to enable Semshi automatically. |
 | `g:semshi#excluded_hl_groups` | `['local']` | List of highlight groups not to highlight. Choose from `local`, `unresolved`, `attribute`, `builtin`, `free`, `global`, `parameter`, `parameterUnused`, `self`, `imported`. (It's recommended to keep `local` in the list because highlighting all locals in a large file can cause performance issues.) |
 | `g:semshi#mark_selected_nodes ` | `1` | Mark selected nodes (those with the same name and scope as the one under the cursor). Set to `2` to highlight the node currently under the cursor, too. |
 | `g:semshi#no_default_builtin_highlight` | `v:true` | Disable highlighting of builtins (`list`, `len`, etc.) by Vim's own Python syntax highlighter, because that's Semshi's job. If you turn it off, Vim may add incorrect highlights. |

--- a/plugin/semshi.vim
+++ b/plugin/semshi.vim
@@ -79,16 +79,15 @@ function! semshi#buffer_attach()
     endif
     let b:semshi_attached = v:true
     augroup SemshiEvents
-        autocmd BufEnter <buffer> call SemshiBufEnter()
+        autocmd BufEnter <buffer> call SemshiBufEnter(+expand('<abuf>'))
         autocmd BufLeave <buffer> call SemshiBufLeave()
         autocmd VimResized <buffer> call SemshiVimResized()
-        autocmd VimLeave <buffer> call SemshiVimLeave()
         autocmd TextChanged <buffer> call SemshiTextChanged()
         autocmd TextChangedI <buffer> call SemshiTextChanged()
         autocmd CursorMoved <buffer> call SemshiCursorMoved()
         autocmd CursorMovedI <buffer> call SemshiCursorMoved()
     augroup END
-    call SemshiBufEnter()
+    call SemshiBufEnter(bufnr('%'))
 endfunction
 
 function! semshi#buffer_detach()
@@ -97,7 +96,6 @@ function! semshi#buffer_detach()
         autocmd! BufEnter <buffer>
         autocmd! BufLeave <buffer>
         autocmd! VimResized <buffer>
-        autocmd! VimLeave <buffer>
         autocmd! TextChanged <buffer>
         autocmd! TextChangedI <buffer>
         autocmd! CursorMoved <buffer>
@@ -114,6 +112,7 @@ function! semshi#init()
     endif
 
     autocmd FileType * call s:filetype_changed()
+    autocmd BufWipeout * call SemshiBufWipeout(+expand('<abuf>'))
 endfunction
 
 call semshi#init()

--- a/plugin/semshi.vim
+++ b/plugin/semshi.vim
@@ -79,15 +79,15 @@ function! semshi#buffer_attach()
     endif
     let b:semshi_attached = v:true
     augroup SemshiEvents
-        autocmd BufEnter <buffer> call SemshiBufEnter(+expand('<abuf>'))
+        autocmd BufEnter <buffer> call SemshiBufEnter(+expand('<abuf>'), line('w0'), line('w$'))
         autocmd BufLeave <buffer> call SemshiBufLeave()
-        autocmd VimResized <buffer> call SemshiVimResized()
+        autocmd VimResized <buffer> call SemshiVimResized(line('w0'), line('w$'))
         autocmd TextChanged <buffer> call SemshiTextChanged()
         autocmd TextChangedI <buffer> call SemshiTextChanged()
-        autocmd CursorMoved <buffer> call SemshiCursorMoved()
-        autocmd CursorMovedI <buffer> call SemshiCursorMoved()
+        autocmd CursorMoved <buffer> call SemshiCursorMoved(line('w0'), line('w$'))
+        autocmd CursorMovedI <buffer> call SemshiCursorMoved(line('w0'), line('w$'))
     augroup END
-    call SemshiBufEnter(bufnr('%'))
+    call SemshiBufEnter(bufnr('%'), line('w0'), line('w$'))
 endfunction
 
 function! semshi#buffer_detach()

--- a/rplugin/python3/semshi/handler.py
+++ b/rplugin/python3/semshi/handler.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from fnmatch import fnmatch
 import threading
 import time
 
@@ -42,8 +41,9 @@ class BufferHandler:
         # Nodes which are currently marked as a selected. We keep track of them
         # to check if they haven't changed between updates.
         self._selected_nodes = []
-        self.enabled = not any(fnmatch(buf.name, pattern) for pattern in
-                               self._options.excluded_buffers)
+
+    def __repr__(self):
+        return '<BufferHandler(%d)>' % self._buf_num
 
     def viewport(self, start, stop):
         """Set viewport to line range from `start` to `stop` and add highlights

--- a/rplugin/python3/semshi/plugin.py
+++ b/rplugin/python3/semshi/plugin.py
@@ -87,6 +87,13 @@ class Plugin:
             self._update_viewport()
             self._cur_handler.update()
 
+    @neovim.autocmd('FileType', pattern='python', sync=True)
+    @if_active
+    def event_file_type(self):
+        if self._cur_handler.enabled:
+            self._update_viewport()
+            self._mark_selected()
+
     @neovim.autocmd('VimResized', pattern=_pattern, sync=False)
     @if_active
     def event_vim_resized(self):

--- a/script/dev.vimrc
+++ b/script/dev.vimrc
@@ -20,7 +20,10 @@ let mapleader = ','
 
 noremap <silent> <S-j> 4j
 noremap <silent> <S-k> 4k
-noremap <silent> <Leader>q :q<CR>
+noremap <silent> q :q<CR>
+noremap <silent> Q :qa!<CR>
+noremap <silent><C-tab> :bnext<CR>
+noremap <silent><C-S-tab> :bprev<CR>
 
 
 function! SynStack()

--- a/test/test_fuzz.py
+++ b/test/test_fuzz.py
@@ -6,7 +6,6 @@ import pytest
 from .conftest import parse, dump_symtable
 
 
-@pytest.mark.fuzz
 def test_multiple_files():
     """Attempt to parse random Python files."""
     for root, dirs, files in os.walk('/usr/lib/python3.8/'):

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -142,6 +142,15 @@ def test_switch_handler(vim, tmp_path):
     assert not vim.host_eval('plugin._cur_handler is None')
 
 
+def test_wipe_buffer(vim, tmp_path):
+    """When a buffer is wiped out, the handler should be removed."""
+    assert vim.host_eval('len(plugin._handlers)') == 0
+    vim.command('edit %s' % (tmp_path / 'foo.py'))
+    assert vim.host_eval('len(plugin._handlers)') == 1
+    vim.command('bwipeout %s' % (tmp_path / 'foo.py'))
+    assert vim.host_eval('len(plugin._handlers)') == 0
+
+
 def test_selected_nodes(vim, tmp_path):
     """When moving the cursor above a node, it's registered as selected"""
     node_positions = lambda: vim.host_eval('[n.pos for n in plugin._cur_handler._selected_nodes]')

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -144,11 +144,22 @@ def test_switch_handler(vim, tmp_path):
 
 def test_wipe_buffer(vim, tmp_path):
     """When a buffer is wiped out, the handler should be removed."""
+    # Without calling a Semshi command first, the subsequent assertions
+    # accessing the plugin may fail
+    vim.command('Semshi')
     assert vim.host_eval('len(plugin._handlers)') == 0
     vim.command('edit %s' % (tmp_path / 'foo.py'))
     assert vim.host_eval('len(plugin._handlers)') == 1
     vim.command('bwipeout %s' % (tmp_path / 'foo.py'))
     assert vim.host_eval('len(plugin._handlers)') == 0
+
+
+def test_cursormoved_before_bufenter(vim, tmp_path):
+    """When CursorMoved is triggered before BufEnter, switch the buffer."""
+    vim.command('edit %s' % (tmp_path / 'foo.py'))
+    vim.command('new %s' % (tmp_path / 'bar.py'))
+    vim.command('q')
+    assert vim.host_eval('plugin._cur_handler._buf_num') == 1
 
 
 def test_selected_nodes(vim, tmp_path):

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     pytest
     pytest-cov
 commands =
-    pytest -v {posargs:--cov semshi/ --cov-report term-missing:skip-covered  test/ -m "not fuzz"}
+    pytest -v {posargs:--cov semshi/ --cov-report term-missing:skip-covered --ignore test/test_fuzz.py test/}
 
 [testenv:lint]
 deps=


### PR DESCRIPTION
- Enable/disable Semshi based on filetypes instead of extensions (closes #35).
- Add option `g:semhi#filetypes`.
- Remove options `g:semshi#active`, `g:semshi#excluded_buffers`. (Vim autocommands can be used as a replacement for the excluded buffers list. An empty list will keep Semshi inactive unless enabled manually via `:Semshi enable`.)