### PR TITLE
Update Deoplete auto_complete_delay advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ Semshi should be snappy on reasonably-sized Python files with ordinary hardware.
 Completion triggers may block Semshi from highlighting instantly. Try to increase Deoplete's `auto_complete_delay`, e.g.:
 
 ```VimL
+call deoplete#custom#option('auto_complete_delay', 100)
+```
+
+Or in older (<=5.2) Deoplete versions:
+
+```VimL
 let g:deoplete#auto_complete_delay = 100
 ```
 


### PR DESCRIPTION
Fixes #85.

New option-setting mechanism taken from Deoplete's in-vim help: [deoplete.txt#L94](https://github.com/Shougo/deoplete.nvim/blob/04a7bfcd997e5178f080ebd368f681545d0d26d6/doc/deoplete.txt#L94)