### PR TITLE
Reset autocommands in `semshi#buffer_attach`

### DIFF
--- a/plugin/semshi.vim
+++ b/plugin/semshi.vim
@@ -79,6 +79,7 @@ function! semshi#buffer_attach()
     endif
     let b:semshi_attached = v:true
     augroup SemshiEvents
+        autocmd! * <buffer>
         autocmd BufEnter <buffer> call SemshiBufEnter(+expand('<abuf>'), line('w0'), line('w$'))
         autocmd BufLeave <buffer> call SemshiBufLeave()
         autocmd VimResized <buffer> call SemshiVimResized(line('w0'), line('w$'))


### PR DESCRIPTION
When a buffer gets unloaded (e.g. `:bdelete`), `b:semshi_attached` will
not be there anymore when the buffer gets loaded/used again.
This typically happens with vim-fugitive, when using `:Gdiff`.