### PR TITLE
Load plugin/rplugin.vim

### DIFF
--- a/plugin/semshi.vim
+++ b/plugin/semshi.vim
@@ -99,6 +99,9 @@ function! semshi#buffer_detach()
 endfunction
 
 function! semshi#init()
+    if !exists('g:loaded_remote_plugins')
+      runtime! plugin/rplugin.vim
+    endif
     if g:semshi#no_default_builtin_highlight
         call s:disable_builtin_highlights()
     endif


### PR DESCRIPTION
Fix #77, #87

This error occurs when you open a python file in neovim 0.5 or higher.
Checked WSL(Ubuntu18.04), Mac Big Sur, Ubuntu18.04

UpdateRemotePlugins alone did not solve the problem, and I thought there was a problem with the loading part of rplugin.vim, so I tentatively fixed it this way.
I'm sure there's another, better idea.