### PR TITLE
fix python comprehension bug

### DIFF
--- a/rplugin/python3/semshi/visitor.py
+++ b/rplugin/python3/semshi/visitor.py
@@ -107,7 +107,7 @@ class Visitor:
                 self._visit_args(node)
                 self._mark_self(node)
         # Either make a new block scope...
-        if type_ in BLOCKS:
+        if type_ in BLOCKS and len(self._table_stack) > 0:
             current_table = self._table_stack.pop()
             self._table_stack += reversed(current_table.get_children())
             self._env.append(current_table)


### PR DESCRIPTION
when editing a python file with comprehension:

a=["yes","yeah","no"]
b=[x for x in a if "y" in x]

semshi explodes:

File "/home/jbiosca/.local/share/nvim/lazy/semshi/rplugin/python3/semshi/visitor.py", line 111, in visit
    current_table = self._table_stack.pop()
                    ^^^^^^^^^^^^^^^^^^^^^^^
IndexError: pop from empty list
stack traceback:
        [C]: in function '_with'
        /usr/share/nvim/runtime/filetype.lua:35: in function </usr/share/nvim/runtime/filetype.lua:10>